### PR TITLE
Prefer regexp \A and \z instead of ^ and $

### DIFF
--- a/lib/rails_rebase_migrations.rb
+++ b/lib/rails_rebase_migrations.rb
@@ -9,7 +9,7 @@ class RebaseMigrations
   SKIP_REBASE = '_skip_rebase_'
 
   MIGRATIONS_DIR = 'db/migrate/'
-  MIGRATION_NAME_RE = /^(\d+)(.*)$/
+  MIGRATION_NAME_RE = /\A(\d+)(.*)\z/
 
   def main
     ref, options = parse_args


### PR DESCRIPTION
From https://docs.ruby-lang.org/en/master/Regexp.html

- ^: Matches the beginning of a line
- $: Matches the end of a line
- \A: Matches the beginning of the string
- \z: Matches the end of the string

As we never anticipate a newline within the file name, using the \A and \z boundaries are more robust.