### PR TITLE
Change gemspec to use "add_dependency"

### DIFF
--- a/rails-rebase-migrations.gemspec
+++ b/rails-rebase-migrations.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.metadata = { 'rubygems_mfa_required' => 'true' }
   spec.required_ruby_version = '>=3.2'
 
-  spec.add_runtime_dependency 'rails', '>= 6.1', '< 8'
+  spec.add_dependency 'rails', '>= 6.1', '< 8'
 end


### PR DESCRIPTION
The "add_runtime_dependency" alias is soft-deprecated inf favor of add_dependency. Fixes RuboCop offense:

```
 rails-response-dumper.gemspec:22:8: C: [Correctable] Gemspec/AddRuntimeDependency: Use add_dependency instead of add_runtime_dependency.
  spec.add_runtime_dependency 'rails', '>= 6.1', '< 8'
       ^^^^^^^^^^^^^^^^^^^^^^
rails-response-dumper.gemspec:23:8: C: [Correctable] Gemspec/AddRuntimeDependency: Use add_dependency instead of add_runtime_dependency.
  spec.add_runtime_dependency 'rspec-mocks', '~> 3.0'
       ^^^^^^^^^^^^^^^^^^^^^^
```