### PR TITLE
Remove upper bound from Rails dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rails-rebase-migrations (1.2.0)
-      rails (>= 6.1, < 9)
+      rails (>= 6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/rails-rebase-migrations.gemspec
+++ b/rails-rebase-migrations.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.metadata = { 'rubygems_mfa_required' => 'true' }
   spec.required_ruby_version = '>=3.2'
 
-  spec.add_dependency 'rails', '>= 6.1', '< 9'
+  spec.add_dependency 'rails', '>= 6.1'
 end


### PR DESCRIPTION
Allow projects using rails-rebase-migrations to update Rails without being blocked by this as a dependency.