### PR TITLE
Checkout db/schema.rb before migrating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+Checkout previous version of `db/schema.rb` before re-applying migrations to
+avoid conflicts.
+
 ## 1.3.0 (2024-11-13)
 
 Add support for Rails 8.

--- a/lib/rails_rebase_migrations.rb
+++ b/lib/rails_rebase_migrations.rb
@@ -71,6 +71,7 @@ class RebaseMigrations
     return if options[:check]
 
     # Regenerate db/schema.rb
+    system('git', 'checkout', ref, '--', 'db/schema.rb', exception: true)
     system('rails', 'db:drop', 'db:create', 'db:migrate', exception: true)
     subprocess('git', 'add', 'db/schema.rb')
   end


### PR DESCRIPTION
As an optimization, when Rails migrates a blank database, it first loads the schema from db/schema.rb. Often, this already has the to-be-rebased migrations applied so it must first be reverted be re-applying.