### PR TITLE
Pin all third party GitHub actions to a specific SHA commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@866b91cc020931c510d42e43e498a7f07d335f60
         with:
           ruby-version: '3.2'
           bundler-cache: true


### PR DESCRIPTION
Previously, the third party GitHub actions were set to a git tag, but git tags are mutable. This means that a malicious agent could switch the tag out from under us to inject new malicious code. However, a SHA is immutable. Once set in the git repository the SHA will never refer a different instance of the code. This is security improvement.

Using a SHA is considered best practices in GitHub actions and discussed in the official docs at:

https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

> You can help mitigate this risk by following these good practices:
>
> - Pin actions to a full-length commit SHA